### PR TITLE
Add explicit IMDS metadata options to NAT instance launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,9 @@ resource "aws_launch_template" "this" {
   }
 
   metadata_options {
+    http_endpoint = "enabled"
+    http_protocol_ipv6 = "disabled"
+    http_put_response_hop_limit = 2
     http_tokens = "required"
   }
 


### PR DESCRIPTION
Configure all metadata_options fields on the launch template to ensure full compliance with account-wide IMDSv2 enforcement (DOR-331):

- http_endpoint: explicitly enabled (required for IMDS availability)
- http_protocol_ipv6: disabled (IPv4-only IMDS access)
- http_put_response_hop_limit: set to 2 (allows containerised/forwarded requests to reach the metadata service)
- http_tokens: required (already present, enforces IMDSv2)

Previously, only http_tokens was set, which could cause issues when account-level IMDS defaults are enforced, as Terraform would detect drift on the unset fields. Explicitly declaring all fields prevents unexpected plan diffs and ensures the launch template is fully self-documenting.

After the merge, apply the following:
- https://github.com/tailsdotcom/infrastructure-tf/blob/main/aws/sandbox/networking/main.tf#L126-L142 